### PR TITLE
Feat/ranking

### DIFF
--- a/src/main/java/com/example/cuckoolandback/ranking/controller/RankingController.java
+++ b/src/main/java/com/example/cuckoolandback/ranking/controller/RankingController.java
@@ -24,4 +24,7 @@ public class RankingController {
     public ResponseEntity<List<RankingResponseDto>> getAllRanking() {
         return ResponseEntity.ok().body(rankingService.getAllMafiaRanking());
     }
+
+
+
 }

--- a/src/main/java/com/example/cuckoolandback/ranking/controller/RankingController.java
+++ b/src/main/java/com/example/cuckoolandback/ranking/controller/RankingController.java
@@ -1,0 +1,27 @@
+package com.example.cuckoolandback.ranking.controller;
+
+import com.example.cuckoolandback.ranking.dto.RankingResponseDto;
+import com.example.cuckoolandback.ranking.service.RankingService;
+import com.example.cuckoolandback.user.service.MemberService;
+import io.swagger.annotations.ApiOperation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/ranking")
+@RequiredArgsConstructor
+public class RankingController {
+
+    final MemberService memberService;
+    private final RankingService rankingService;
+
+    @ApiOperation(value = "마피아 전체 랭킹 조회")
+    @GetMapping("/mafia/total")
+    public ResponseEntity<List<RankingResponseDto>> getAllRanking() {
+        return ResponseEntity.ok().body(rankingService.getAllMafiaRanking());
+    }
+}

--- a/src/main/java/com/example/cuckoolandback/ranking/controller/RankingController.java
+++ b/src/main/java/com/example/cuckoolandback/ranking/controller/RankingController.java
@@ -21,10 +21,15 @@ public class RankingController {
 
     @ApiOperation(value = "마피아 전체 랭킹 조회")
     @GetMapping("/mafia/total")
-    public ResponseEntity<List<RankingResponseDto>> getAllRanking() {
+    public ResponseEntity<List<RankingResponseDto>> getAllMafiaRanking() {
         return ResponseEntity.ok().body(rankingService.getAllMafiaRanking());
     }
 
+    @ApiOperation(value = "다수결 전체 랭킹 조회")
+    @GetMapping("/majority/total")
+    public ResponseEntity<List<RankingResponseDto>> getAllMajorRanking() {
+        return ResponseEntity.ok().body(rankingService.getAllMajorRanking());
+    }
 
 
 }

--- a/src/main/java/com/example/cuckoolandback/ranking/controller/RankingController.java
+++ b/src/main/java/com/example/cuckoolandback/ranking/controller/RankingController.java
@@ -25,9 +25,10 @@ public class RankingController {
     public ResponseEntity<List<RankingResponseDto>> getAllMafiaRanking() {
         return ResponseEntity.ok().body(rankingService.getAllMafiaRanking());
     }
+
     @ApiOperation(value = "마피아 상세 랭킹 조회")
     @GetMapping("/majority/{memberid}")
-    public ResponseEntity<RankingResponseDto> getOneMafiaRanking(@PathVariable String memberid){
+    public ResponseEntity<RankingResponseDto> getOneMafiaRanking(@PathVariable String memberid) {
         return ResponseEntity.ok().body(rankingService.getOneMafiaRanking(memberid));
     }
 
@@ -36,6 +37,11 @@ public class RankingController {
     @GetMapping("/majority/total")
     public ResponseEntity<List<RankingResponseDto>> getAllMajorRanking() {
         return ResponseEntity.ok().body(rankingService.getAllMajorRanking());
+    }
+    @ApiOperation(value = "다수결 상세 랭킹 조회")
+    @GetMapping("/majority/{memberid}")
+    public ResponseEntity<RankingResponseDto> getOneMajorRanking(@PathVariable String memberid) {
+        return ResponseEntity.ok().body(rankingService.getOneMajorRanking(memberid));
     }
 
 

--- a/src/main/java/com/example/cuckoolandback/ranking/controller/RankingController.java
+++ b/src/main/java/com/example/cuckoolandback/ranking/controller/RankingController.java
@@ -8,6 +8,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,6 +25,12 @@ public class RankingController {
     public ResponseEntity<List<RankingResponseDto>> getAllMafiaRanking() {
         return ResponseEntity.ok().body(rankingService.getAllMafiaRanking());
     }
+    @ApiOperation(value = "마피아 상세 랭킹 조회")
+    @GetMapping("/majority/{memberid}")
+    public ResponseEntity<RankingResponseDto> getOneMafiaRanking(@PathVariable String memberid){
+        return ResponseEntity.ok().body(rankingService.getOneMafiaRanking(memberid));
+    }
+
 
     @ApiOperation(value = "다수결 전체 랭킹 조회")
     @GetMapping("/majority/total")

--- a/src/main/java/com/example/cuckoolandback/ranking/dto/RankingResponseDto.java
+++ b/src/main/java/com/example/cuckoolandback/ranking/dto/RankingResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.cuckoolandback.ranking.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RankingResponseDto {
+    private String mafiaWinNum;
+    private int mafiaWinScore;
+    private String mafiaTier;
+    private String majorWinNum;
+    private int majorWinScore;
+    private String majorTier;
+}

--- a/src/main/java/com/example/cuckoolandback/ranking/dto/RankingResponseDto.java
+++ b/src/main/java/com/example/cuckoolandback/ranking/dto/RankingResponseDto.java
@@ -6,10 +6,8 @@ import lombok.Getter;
 @Getter
 @Builder
 public class RankingResponseDto {
-    private String mafiaWinNum;
-    private int mafiaWinScore;
-    private String mafiaTier;
-    private String majorWinNum;
-    private int majorWinScore;
-    private String majorTier;
+    private String nickname;
+    private int tier;
+    private String winNum;
+    private int winScore;
 }

--- a/src/main/java/com/example/cuckoolandback/ranking/repository/RankingRepository.java
+++ b/src/main/java/com/example/cuckoolandback/ranking/repository/RankingRepository.java
@@ -1,8 +1,0 @@
-package com.example.cuckoolandback.ranking.repository;
-
-import com.example.cuckoolandback.friend.domain.Friend;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface RankingRepository extends JpaRepository<Friend, Long> {
-
-}

--- a/src/main/java/com/example/cuckoolandback/ranking/repository/RankingRepository.java
+++ b/src/main/java/com/example/cuckoolandback/ranking/repository/RankingRepository.java
@@ -1,0 +1,8 @@
+package com.example.cuckoolandback.ranking.repository;
+
+import com.example.cuckoolandback.friend.domain.Friend;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RankingRepository extends JpaRepository<Friend, Long> {
+
+}

--- a/src/main/java/com/example/cuckoolandback/ranking/service/RankingService.java
+++ b/src/main/java/com/example/cuckoolandback/ranking/service/RankingService.java
@@ -1,0 +1,33 @@
+package com.example.cuckoolandback.ranking.service;
+
+import com.example.cuckoolandback.ranking.dto.RankingResponseDto;
+import com.example.cuckoolandback.user.domain.Member;
+import com.example.cuckoolandback.user.repository.MemberRepository;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RankingService {
+
+    private final MemberRepository memberRepository;
+
+    public RankingService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    public List<RankingResponseDto> getAllMafiaRanking() {
+        List<RankingResponseDto> rankingResponseDtoList = new ArrayList<>();
+        List<Member> memberList = memberRepository.findTopByMafiaWinScore();
+        for (Member member : memberList) {
+            RankingResponseDto rankingResponseDto = RankingResponseDto.builder()
+                .mafiaWinNum(member.getMafiaWinNum())
+                .majorWinScore(member.getMajorWinScore())
+                .mafiaTier(member.getMafiaTier())
+                .majorWinNum(member.getMajorWinNum())
+                .majorWinScore(member.getMajorWinScore())
+                .majorTier(member.getMajorTier())
+                .build();
+            rankingResponseDtoList.add(rankingResponseDto);
+        }
+        return rankingResponseDtoList;
+    }
+}

--- a/src/main/java/com/example/cuckoolandback/ranking/service/RankingService.java
+++ b/src/main/java/com/example/cuckoolandback/ranking/service/RankingService.java
@@ -28,4 +28,21 @@ public class RankingService {
         }
         return rankingResponseDtoList;
     }
+
+    public List<RankingResponseDto> getAllMajorRanking() {
+        List<RankingResponseDto> rankingResponseDtoList = new ArrayList<>();
+        List<Member> memberList = memberRepository.findTopByMajorWinScore();
+        for (Member member : memberList) {
+            RankingResponseDto rankingResponseDto = RankingResponseDto.builder()
+                .nickname(member.getNickname())
+                .tier(member.getMajorTier())
+                .winNum(member.getMajorWinNum())
+                .winScore(member.getMajorWinScore())
+                .build();
+            rankingResponseDtoList.add(rankingResponseDto);
+        }
+        return rankingResponseDtoList;
+    }
+
+
 }

--- a/src/main/java/com/example/cuckoolandback/ranking/service/RankingService.java
+++ b/src/main/java/com/example/cuckoolandback/ranking/service/RankingService.java
@@ -19,12 +19,10 @@ public class RankingService {
         List<Member> memberList = memberRepository.findTopByMafiaWinScore();
         for (Member member : memberList) {
             RankingResponseDto rankingResponseDto = RankingResponseDto.builder()
-                .mafiaWinNum(member.getMafiaWinNum())
-                .majorWinScore(member.getMajorWinScore())
-                .mafiaTier(member.getMafiaTier())
-                .majorWinNum(member.getMajorWinNum())
-                .majorWinScore(member.getMajorWinScore())
-                .majorTier(member.getMajorTier())
+                .nickname(member.getNickname())
+                .tier(member.getMafiaTier())
+                .winNum(member.getMafiaWinNum())
+                .winScore(member.getMafiaWinScore())
                 .build();
             rankingResponseDtoList.add(rankingResponseDto);
         }

--- a/src/main/java/com/example/cuckoolandback/ranking/service/RankingService.java
+++ b/src/main/java/com/example/cuckoolandback/ranking/service/RankingService.java
@@ -4,11 +4,9 @@ import com.example.cuckoolandback.common.exception.CustomException;
 import com.example.cuckoolandback.common.exception.ErrorCode;
 import com.example.cuckoolandback.ranking.dto.RankingResponseDto;
 import com.example.cuckoolandback.user.domain.Member;
-import com.example.cuckoolandback.user.domain.UserDetailsImpl;
 import com.example.cuckoolandback.user.repository.MemberRepository;
 import java.util.ArrayList;
 import java.util.List;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 public class RankingService {
 
@@ -59,6 +57,18 @@ public class RankingService {
             rankingResponseDtoList.add(rankingResponseDto);
         }
         return rankingResponseDtoList;
+    }
+    public RankingResponseDto getOneMajorRanking(String memberid) {
+        Member member = memberRepository.findByMemberId(memberid)
+            .orElseThrow(() -> new CustomException(
+                ErrorCode.USER_NOT_FOUND));
+        RankingResponseDto rankingResponseDto = RankingResponseDto.builder()
+            .nickname(member.getNickname())
+            .tier(member.getMajorTier())
+            .winNum(member.getMajorWinNum())
+            .winScore(member.getMajorWinScore())
+            .build();
+        return rankingResponseDto;
     }
 
 

--- a/src/main/java/com/example/cuckoolandback/ranking/service/RankingService.java
+++ b/src/main/java/com/example/cuckoolandback/ranking/service/RankingService.java
@@ -1,10 +1,14 @@
 package com.example.cuckoolandback.ranking.service;
 
+import com.example.cuckoolandback.common.exception.CustomException;
+import com.example.cuckoolandback.common.exception.ErrorCode;
 import com.example.cuckoolandback.ranking.dto.RankingResponseDto;
 import com.example.cuckoolandback.user.domain.Member;
+import com.example.cuckoolandback.user.domain.UserDetailsImpl;
 import com.example.cuckoolandback.user.repository.MemberRepository;
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 public class RankingService {
 
@@ -27,6 +31,19 @@ public class RankingService {
             rankingResponseDtoList.add(rankingResponseDto);
         }
         return rankingResponseDtoList;
+    }
+
+    public RankingResponseDto getOneMafiaRanking(String memberid) {
+        Member member = memberRepository.findByMemberId(memberid)
+            .orElseThrow(() -> new CustomException(
+                ErrorCode.USER_NOT_FOUND));
+        RankingResponseDto rankingResponseDto = RankingResponseDto.builder()
+            .nickname(member.getNickname())
+            .tier(member.getMafiaTier())
+            .winNum(member.getMafiaWinNum())
+            .winScore(member.getMafiaWinScore())
+            .build();
+        return rankingResponseDto;
     }
 
     public List<RankingResponseDto> getAllMajorRanking() {

--- a/src/main/java/com/example/cuckoolandback/user/domain/Member.java
+++ b/src/main/java/com/example/cuckoolandback/user/domain/Member.java
@@ -24,6 +24,16 @@ public class Member extends BaseTime {
 
     private String password;
 
+    //랭킹 관련
+    private String mafiaWinNum;
+    private int mafiaWinScore;
+    private String mafiaTier;
+    private String majorWinNum;
+    private int majorWinScore;
+    private String majorTier;
+
+    private String memo;
+
     @Enumerated(EnumType.STRING)
     private RoleType roleType;
 

--- a/src/main/java/com/example/cuckoolandback/user/domain/Member.java
+++ b/src/main/java/com/example/cuckoolandback/user/domain/Member.java
@@ -27,10 +27,10 @@ public class Member extends BaseTime {
     //랭킹 관련
     private String mafiaWinNum;
     private int mafiaWinScore;
-    private String mafiaTier;
+    private int mafiaTier;
     private String majorWinNum;
     private int majorWinScore;
-    private String majorTier;
+    private int majorTier;
 
     private String memo;
 

--- a/src/main/java/com/example/cuckoolandback/user/repository/MemberRepository.java
+++ b/src/main/java/com/example/cuckoolandback/user/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.example.cuckoolandback.user.repository;
 
 import com.example.cuckoolandback.user.domain.Member;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +9,6 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByMemberId(String memberId);
     Optional<Member> findByNickname(String nickname);
+
+    List<Member> findTopByMafiaWinScore();
 }

--- a/src/main/java/com/example/cuckoolandback/user/repository/MemberRepository.java
+++ b/src/main/java/com/example/cuckoolandback/user/repository/MemberRepository.java
@@ -11,4 +11,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByNickname(String nickname);
 
     List<Member> findTopByMafiaWinScore();
+    List<Member> findTopByMajorWinScore();
 }


### PR DESCRIPTION
- 마피아 전체 랭킹 조회
- 마피아 상세 랭킹 조회
- 다수결 전체 랭킹 조회
- 다수결 상세 랭킹 조회

* 게임 별(마피아, 다수결) 랭킹을 나눠 조회하기 위해 각 게임별 점수를 저장하도록 Member에 추가했으나, 더 좋은 방법이 있으면 알려주시면 감사하겠습니다!
* 상세 로직은 게임이 다 구현되면 추가할 예정입니다.
